### PR TITLE
changed date validation to use node-validator

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -42,7 +42,7 @@ module.exports = {
 
 	'array'		: _.isArray,
 
-	'date'		: _.isDate,
+	'date'		: function (x) { return check(x).isDate(); },
 
 	'hexadecimal': function (x) { return check(x).hexadecimal(); },
 	'hexColor': function (x) { return check(x).hexColor(); },


### PR DESCRIPTION
_.isDate only check for the `Date` object.  The node-validator is much more flexible.
