### PR TITLE
remove lowercase on the ruleName

### DIFF
--- a/lib/match.js
+++ b/lib/match.js
@@ -17,9 +17,6 @@ var maxDepth = 50;
 function match ( data, ruleName, args ) {
 	var errors = [];
 
-	// Lowercase ruleName
-	ruleName = ruleName.toLowerCase();
-
 	// Ensure args is a list, then prepend it with data
 	if ( !_.isArray(args) ) {
 		args = [args];


### PR DESCRIPTION
So the patch you added that lowercases the rule name breaks rules with camel cased names such at maxLength and notContains.

I removed it for now so Waterline will work. We can either lowercase all the rule names in the rules file and add it back or just tell people to use the correct rule names.

I fixed Waterline so the types will always be lowercased.
