### PR TITLE
Binary data type needs a validation rule.

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -54,6 +54,8 @@ module.exports = {
 
 	'array'		: _.isArray,
 
+	'binary'	: function (x) { return Buffer.isBuffer(x) || _.isString(x) },
+
 	'date'		: function (x) { return check(x).isDate(); },
 	'datetime': function (x) { return check(x).isDate(); },
 


### PR DESCRIPTION
Binary data can be a Buffer or a string (such as of hex digits).

Waterline depends on Anchor, and Waterline had binary support.
However, storing binary data would fail because there was no
validation test and no native binary data type in javascript/V8.

There should be a waterline integration test that checks if binary
data (buffers, strings) are being stored correctly.  Not sure how
binary data types worked at all before this in Waterline?
