### PR TITLE
Update validator to 1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "validator": "0.4.22",
+    "validator": "1.5.0",
     "underscore": "1.4.4",
     "async": "0.2.6"
   }


### PR DESCRIPTION
Previously used 0.4.22, which did not have support
for a number of newly used types in waterline (eg, UUID and UUIDv4/v5)
