### PR TITLE
Split rules and add messages.

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,7 +192,7 @@ Anchor.prototype.define = function (name, definition) {
 
 		// if so all the attributes should be validation functions
 		for (var attr in name){
-			if(!util.isFunction(name[attr])){
+			if(!util.isFunction(name[attr].validate)){
 				throw new Error('Definition error: \"' + attr + '\" does not have a definition');
 			}
 		}
@@ -204,7 +204,7 @@ Anchor.prototype.define = function (name, definition) {
 
 	}
 
-	if ( util.isFunction(definition) && util.isString(name) ) {
+	if ( util.isFunction(definition.validate) && util.isString(name) ) {
 
 		// Add a single data type
 		Anchor.prototype.rules[name] = definition;

--- a/lib/match.js
+++ b/lib/match.js
@@ -5,6 +5,16 @@
 var _ = require('lodash');
 var rules = require('./rules');
 
+function formatErrorMessage(format) {
+  var args = Array.prototype.slice.call(arguments, 1);
+  var sprintfRegex = /\{(\d+)\}/g;
+
+  var sprintf = function (match, number) {
+    return number in args ? args[number] : match;
+  };
+
+  return format.replace(sprintfRegex, sprintf);
+};
 
 /**
  * Expose functions
@@ -50,7 +60,7 @@ function match ( data, ruleName, args ) {
 		throw new Error ('Unknown rule: ' + ruleName);
 	}
 	try {
-		outcome = rule.apply(self, args);
+		outcome = rule.validate.apply(self, args);
 	}
 	catch (e) {
 		outcome = false;
@@ -70,9 +80,7 @@ function match ( data, ruleName, args ) {
 		args.shift();
 
 		// Construct error message
-		var errMsg = '';
-		errMsg += 'Validation error: "'+data+'" ';
-		errMsg += 'Rule "' + ruleName + '(' + args.join(',') + ')" failed.';
+		var errMsg = formatErrorMessage(rule.message, data, args);
 
 		// Construct error object
 		return [{
@@ -180,11 +188,11 @@ function matchType (datum, ruleName, keyName) {
 		// Determine rule
 		if (_.isEqual(ruleName,[])) {
 			// [] specified as data type checks for an array
-			rule = _.isArray;
+			rule = rules['array'];
 		}
 		else if (_.isEqual(ruleName,{})) {
 			// {} specified as data type checks for any object
-			rule = _.isObject;
+			rule = rules['object'];
 		}
 		else if (_.isRegExp(ruleName)) {
 			// Allow regexes to be used
@@ -193,8 +201,9 @@ function matchType (datum, ruleName, keyName) {
 				// fail on 'string' validation
 				if (!_.isString(x)) {
 					rule = rules['string'];
+				} else {
+					x.match.call(self, ruleName);
 				}
-				else x.match.call(self, ruleName);
 			};
 		}
 		// Lookup rule
@@ -205,7 +214,7 @@ function matchType (datum, ruleName, keyName) {
 		if (!rule) {
 			throw new Error ('Unknown rule: ' + ruleName);
 		}
-		else outcome = rule.call(self, datum);
+		else outcome = rule.validate.call(self, datum);
 
 		// If validation failed, return an error
 		if (!outcome) {

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -2,112 +2,11 @@
  * Module dependencies
  */
 
-var _ = require('lodash');
-var check = require('validator').check;
+var fs = require('fs');
 
-
-
-/**
- * Type rules
- */
-
-module.exports = {
-
-	'empty'		: _.isEmpty,
-
-	'required'	: function (x) {
-		// Transform data to work properly with node validator
-		if(!x && x !== 0) x = '';
-		else if(typeof x.toString !== 'undefined') x = x.toString();
-		else x = '' + x;
-
-		return check(x).notEmpty();
-	},
-
-	'notEmpty'	: function (x) {
-
-		// Transform data to work properly with node validator
-		if (!x) x = '';
-		else if (typeof x.toString !== 'undefined') x = x.toString();
-		else x = '' + x;
-
-		return check(x).notEmpty();
-	},
-
-	'undefined'	: _.isUndefined,
-
-	'object'  : _.isObject,
-	'json'    : function (x) {
-		if (_.isUndefined(x)) return false;
-		try { JSON.stringify(x); }
-		catch(err) { return false; }
-		return true;
-	},
-
-	'text'		: _.isString,
-	'string'	: _.isString,
-    'alpha'     : function (x){ return check(x).isAlpha();},
-	'alphadashed': function (x) {return /^[a-zA-Z-_]*$/.test(x)},
-	'numeric'	: function (x){ return check(x).isNumeric();},
-    'alphanumeric': function (x){ return check(x).isAlphanumeric();},
-	'alphanumericdashed': function (x) {return /^[a-zA-Z0-9-_]*$/.test(x)},
-	'email'		: function (x){ return check(x).isEmail();},
-	'url'		: function (x){ return check(x).isUrl();},
-	'urlish'	: /^\s([^\/]+\.)+.+\s*$/g,
-	'ip'		: function (x){ return check(x).isIP(); },
-	'ipv4'		: function (x){ return check(x).isIPv4(); },
-	'ipv6'		: function (x){ return check(x).isIPv6(); },
-	'creditcard': function (x){ return check(x).isCreditCard();},
-	'uuid'		: function (x, version){ return check(x).isUUID(version);},
-	'uuidv3'	: function (x){ return check(x).isUUIDv3();},
-	'uuidv4'	: function (x){ return check(x).isUUIDv4();},
-
-	'int'		: function (x) { return check(x).isInt(); },
-	'integer'	: function (x) { return check(x).isInt(); },
-	'number'	: _.isNumber,
-	'finite'	: _.isFinite,
-
-	'decimal'	: function (x) { return check(x).isDecimal(); },
-	'float'		: function (x) { return check(x).isDecimal(); },
-
-	'falsey'	: function (x) { return !x; },
-	'truthy'	: function (x) { return !!x; },
-	'null'		: _.isNull,
-	'notNull'	: function (x) { return check(x).notNull(); },
-
-	'boolean'	: _.isBoolean,
-
-	'array'		: _.isArray,
-
-	'binary'	: function (x) { return Buffer.isBuffer(x) || _.isString(x); },
-
-	'date'		: function (x) { return check(x).isDate(); },
-	'datetime': function (x) { return check(x).isDate(); },
-
-	'hexadecimal': function (x) { return check(x).hexadecimal(); },
-	'hexColor': function (x) { return check(x).isHexColor(); },
-
-	'lowercase': function (x) { return check(x).lowercase(); },
-	'uppercase': function (x) { return check(x).uppercase(); },
-
-	// Miscellaneous rules
-	'after'		: function (x,date) { return check(x).isAfter(date); },
-	'before'	: function (x,date) { return check(x).isBefore(date); },
-
-	'is'		: function (x, regex) { return check(x).is(regex); },
-	'regex'		: function (x, regex) { return check(x).regex(regex); },
-	'not'		: function (x, regex) { return check(x).not(regex); },
-	'notRegex'	: function (x, regex) { return check(x).notRegex(regex); },
-
-	'equals'	: function (x, equals) { return check(x).equals(equals); },
-	'contains'	: function (x, str) { return check(x).contains(str); },
-	'notContains': function (x, str) { return check(x).notContains(str); },
-	'len'		: function (x, min, max) { return check(x).len(min, max); },
-	'in'		: function (x, arrayOrString) { return check(x).isIn(arrayOrString); },
-	'notIn'		: function (x, arrayOrString) { return check(x).notIn(arrayOrString); },
-	'max'		: function (x, val) { return check(x).max(val); },
-	'min'		: function (x, val) { return check(x).min(val); },
-	'minLength'	: function (x, min) { return check(x).len(min); },
-	'maxLength'	: function (x, max) { return check(x).len(0, max); }
-
-};
+var files = fs.readdirSync('./lib/rules/');
+for (var i in files) {
+  var fileName = './rules/' + files[i];
+  var ruleName = files[i].replace('.js', '');
+  module.exports[ruleName] = require(fileName);
+}

--- a/lib/rules/after.js
+++ b/lib/rules/after.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x, date) {
+    return check(x).isAfter(date);
+  },
+  message: '{0} should be a date after {1}.'
+};

--- a/lib/rules/alpha.js
+++ b/lib/rules/alpha.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isAlpha();
+  },
+  message: '{0} should contain only alphabet characters.'
+};

--- a/lib/rules/alphadashed.js
+++ b/lib/rules/alphadashed.js
@@ -1,0 +1,7 @@
+module.exports = {
+
+  validate: function (x) {
+    return /^[a-zA-Z-_]*$/.test(x);
+  },
+  message: '{0} should contain only alphabet characters or dashes.'
+};

--- a/lib/rules/alphanumeric.js
+++ b/lib/rules/alphanumeric.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isAlphanumeric();
+  },
+  message: '{0} should contain only alphabet and numeric characters.'
+};

--- a/lib/rules/alphanumericdashed.js
+++ b/lib/rules/alphanumericdashed.js
@@ -1,0 +1,7 @@
+module.exports = {
+
+  validate: function (x) {
+    return /^[a-zA-Z0-9-_]*$/.test(x);
+  },
+  message: '{0} should contain only alphabet and numeric characters or dashes.'
+};

--- a/lib/rules/array.js
+++ b/lib/rules/array.js
@@ -1,0 +1,7 @@
+var _ = require('lodash');
+
+module.exports = {
+
+  validate: _.isArray,
+  message: '{0} should be an array.'
+};

--- a/lib/rules/before.js
+++ b/lib/rules/before.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x, date) {
+    return check(x).isBefore(date);
+  },
+  message: '{0} should be a date before {1}.'
+};

--- a/lib/rules/binary.js
+++ b/lib/rules/binary.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return Buffer.isBuffer(x) || _.isString(x);
+  },
+  message: '{0} should be binary.'
+};

--- a/lib/rules/boolean.js
+++ b/lib/rules/boolean.js
@@ -1,0 +1,7 @@
+var _ = require('lodash');
+
+module.exports = {
+
+    validate: _.isBoolean,
+    message: '{0} should be boolean.'
+};

--- a/lib/rules/contains.js
+++ b/lib/rules/contains.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x, str) {
+    return check(x).contains(str);
+  },
+  message: '{0} should contain {1}.'
+};

--- a/lib/rules/creditcard.js
+++ b/lib/rules/creditcard.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isCreditCard();
+  },
+  message: '{0} should be a valid credit card number.'
+};

--- a/lib/rules/date.js
+++ b/lib/rules/date.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isDate();
+  },
+  message: '{0} should be a valid date.'
+};

--- a/lib/rules/datetime.js
+++ b/lib/rules/datetime.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isDate();
+  },
+  message: '{0} should be a valid date.'
+};

--- a/lib/rules/decimal.js
+++ b/lib/rules/decimal.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isDecimal();
+  },
+  message: '{0} should be a valid floating point number.'
+};

--- a/lib/rules/email.js
+++ b/lib/rules/email.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isEmail();
+  },
+  message: '{0} should be a valid email.'
+};

--- a/lib/rules/empty.js
+++ b/lib/rules/empty.js
@@ -1,0 +1,7 @@
+var _ = require('lodash');
+
+module.exports = {
+
+  validate: _.isEmpty,
+  message: '{0} should be empty.'
+};

--- a/lib/rules/equals.js
+++ b/lib/rules/equals.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x, equals) {
+    return check(x).equals(equals);
+  },
+  message: '{0} should equal {1}.'
+};

--- a/lib/rules/falsey.js
+++ b/lib/rules/falsey.js
@@ -1,0 +1,7 @@
+module.exports = {
+
+  validate: function (x) {
+    return !x;
+  },
+  message: '{0} should be falsey.'
+};

--- a/lib/rules/finite.js
+++ b/lib/rules/finite.js
@@ -1,0 +1,7 @@
+var _ = require('lodash');
+
+module.exports = {
+
+  validate: _.isFinite,
+  message: '{0} should be finite.'
+};

--- a/lib/rules/float.js
+++ b/lib/rules/float.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isDecimal();
+  },
+  message: '{0} should be a valid floating point number.'
+};

--- a/lib/rules/hexColor.js
+++ b/lib/rules/hexColor.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isHexColor();
+  },
+  message: '{0} should be a valid hex color.'
+};

--- a/lib/rules/hexadecimal.js
+++ b/lib/rules/hexadecimal.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).hexadecimal();
+  },
+  message: '{0} should be a valid hexadecimal number.'
+};

--- a/lib/rules/in.js
+++ b/lib/rules/in.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x, arrayOrString) {
+    return check(x).isIn(arrayOrString);
+  },
+  message: '{0} should be in {1}.'
+};

--- a/lib/rules/int.js
+++ b/lib/rules/int.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isInt();
+  },
+  message: '{0} should be a valid integer.'
+};

--- a/lib/rules/integer.js
+++ b/lib/rules/integer.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isInt();
+  },
+  message: '{0} should be a valid integer.'
+};

--- a/lib/rules/ip.js
+++ b/lib/rules/ip.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isIP();
+  },
+  message: '{0} should be a valid IP.'
+};

--- a/lib/rules/ipv4.js
+++ b/lib/rules/ipv4.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isIPv4();
+  },
+  message: '{0} should be a valid IPv4.'
+};

--- a/lib/rules/ipv6.js
+++ b/lib/rules/ipv6.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isIPv6();
+  },
+  message: '{0} should be a valid IPv6.'
+};

--- a/lib/rules/is.js
+++ b/lib/rules/is.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x, regex) {
+    return check(x).is(regex);
+  },
+  message: '{0} should be {1}.'
+};

--- a/lib/rules/json.js
+++ b/lib/rules/json.js
@@ -1,0 +1,17 @@
+var _ = require('lodash');
+
+module.exports = {
+
+  validate: function (x) {
+    if (_.isUndefined(x)) {
+      return false;
+    }
+    try {
+      JSON.stringify(x);
+    } catch(err) {
+      return false;
+    }
+    return true;
+  },
+  message: '{0} should be a JSON object.'
+};

--- a/lib/rules/len.js
+++ b/lib/rules/len.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x, min, max) {
+    return check(x).len(min, max);
+  },
+  message: '{0} should be between {1} and {2}.'
+};

--- a/lib/rules/lowercase.js
+++ b/lib/rules/lowercase.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).lowercase();
+  },
+  message: '{0} should be lowercase.'
+};

--- a/lib/rules/max.js
+++ b/lib/rules/max.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x, val) {
+    return check(x).max(val);
+  },
+  message: '{0} should be at max {1}.'
+};

--- a/lib/rules/maxLength.js
+++ b/lib/rules/maxLength.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x, max) {
+    return check(x).len(0, max);
+  },
+  message: '{0} length should be less than {1}.'
+};

--- a/lib/rules/min.js
+++ b/lib/rules/min.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x, val) {
+    return check(x).min(val);
+  },
+  message: '{0} should be at min {1}.'
+};

--- a/lib/rules/minLength.js
+++ b/lib/rules/minLength.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x, min) {
+    return check(x).len(min);
+  },
+  message: '{0} length should be more than {1}.'
+};

--- a/lib/rules/not.js
+++ b/lib/rules/not.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x, regex) {
+    return check(x).not(regex);
+  },
+  message: '{0} should not be {1}.'
+};

--- a/lib/rules/notContains.js
+++ b/lib/rules/notContains.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x, str) {
+    return check(x).notContains(str);
+  },
+  message: '{0} should not contain {1}.'
+};

--- a/lib/rules/notEmpty.js
+++ b/lib/rules/notEmpty.js
@@ -1,0 +1,17 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    // Transform data to work properly with node validator
+    if (!x) {
+      x = '';
+    } else if (typeof x.toString !== 'undefined') {
+      x = x.toString();
+    } else {
+      x = '' + x;
+    }
+    return check(x).notEmpty();
+  },
+  message: '{0} should not be empty.'
+};

--- a/lib/rules/notIn.js
+++ b/lib/rules/notIn.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x, arrayOrString) {
+    return check(x).notIn(arrayOrString);
+  },
+  message: '{0} should not be in {1}.'
+};

--- a/lib/rules/notNull.js
+++ b/lib/rules/notNull.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).notNull();
+  },
+  message: '{0} should not be null.'
+};

--- a/lib/rules/notRegex.js
+++ b/lib/rules/notRegex.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x, regex) {
+    return check(x).notRegex(regex);
+  },
+  message: '{0} should not match {1}.'
+};

--- a/lib/rules/null.js
+++ b/lib/rules/null.js
@@ -1,0 +1,7 @@
+var _ = require('lodash');
+
+module.exports = {
+
+  validate: _.isNull,
+  message: '{0} should be null.'
+};

--- a/lib/rules/number.js
+++ b/lib/rules/number.js
@@ -1,0 +1,7 @@
+var _ = require('lodash');
+
+module.exports = {
+
+  validate: _.isNumber,
+  message: '{0} should be a number.'
+};

--- a/lib/rules/numeric.js
+++ b/lib/rules/numeric.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isNumeric();
+  },
+  message: '{0} should contain only numeric characters.'
+};

--- a/lib/rules/object.js
+++ b/lib/rules/object.js
@@ -1,0 +1,7 @@
+var _ = require('lodash');
+
+module.exports = {
+
+  validate: _.isObject,
+  message: '{0} should be an object.'
+};

--- a/lib/rules/regex.js
+++ b/lib/rules/regex.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x, regex) {
+    return check(x).regex(regex);
+  },
+  message: '{0} should match {1}.'
+};

--- a/lib/rules/required.js
+++ b/lib/rules/required.js
@@ -1,0 +1,17 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    // Transform data to work properly with node validator
+    if (!x && x !== 0) {
+      x = '';
+    } else if (typeof x.toString !== 'undefined') {
+      x = x.toString();
+    } else {
+      x = '' + x;
+    }
+    return check(x).notEmpty();
+  },
+  message: '{0} is required.'
+};

--- a/lib/rules/string.js
+++ b/lib/rules/string.js
@@ -1,0 +1,7 @@
+var _ = require('lodash');
+
+module.exports = {
+
+  validate: _.isString,
+  message: '{0} should be text.'
+};

--- a/lib/rules/text.js
+++ b/lib/rules/text.js
@@ -1,0 +1,7 @@
+var _ = require('lodash');
+
+module.exports = {
+
+  validate: _.isString,
+  message: '{0} should be text.'
+};

--- a/lib/rules/truthy.js
+++ b/lib/rules/truthy.js
@@ -1,0 +1,7 @@
+module.exports = {
+
+  validate: function (x) {
+    return !!x;
+  },
+  message: '{0} should be truthy.'
+};

--- a/lib/rules/undefined.js
+++ b/lib/rules/undefined.js
@@ -1,0 +1,7 @@
+var _ = require('lodash');
+
+module.exports = {
+
+  validate: _.isUndefined,
+  message: '{0} should be undefined.'
+};

--- a/lib/rules/uppercase.js
+++ b/lib/rules/uppercase.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).uppercase();
+  },
+  message: '{0} should be uppercase.'
+};

--- a/lib/rules/url.js
+++ b/lib/rules/url.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isUrl();
+  },
+  message: '{0} should be a valid URL.'
+};

--- a/lib/rules/urlish.js
+++ b/lib/rules/urlish.js
@@ -1,0 +1,7 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: /^\s([^\/]+\.)+.+\s*$/g,
+  message: '{0} should look like a URL.'
+};

--- a/lib/rules/uuid.js
+++ b/lib/rules/uuid.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x, version) {
+    return check(x).isUUID(version);
+  },
+  message: '{0} should be a valid UUID of version {1}.'
+};

--- a/lib/rules/uuidv3.js
+++ b/lib/rules/uuidv3.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isUUIDv3();
+  },
+  message: '{0} should be a valid UUID of version 3.'
+};

--- a/lib/rules/uuidv4.js
+++ b/lib/rules/uuidv4.js
@@ -1,0 +1,9 @@
+var check = require('validator').check;
+
+module.exports = {
+
+  validate: function (x) {
+    return check(x).isUUIDv4();
+  },
+  message: '{0} should be a valid UUID of version 4.'
+};

--- a/test/defineType.test.js
+++ b/test/defineType.test.js
@@ -14,8 +14,11 @@ describe('Custom Types', function() {
 				houseNumber: 5
 			},
 
-			isfive = function(val){
-				return val === 5;
+			isfive = {
+				validate: function(val){
+					return val === 5;
+				},
+				message: "{0} should be equal to 5."
 			};
 
 			assert.equal(false, anchor(example).define("five", isfive).to({type:rules}));
@@ -34,11 +37,17 @@ describe('Custom Types', function() {
 			},
 
 			definition = {
-				five: function(val){
-					return val === 5;
+				five: {
+					validate: function(val){
+						return val === 5;
+					},
+					message: "{0} should be equal to 5."
 				},
-				yummyFish: function(val){
-					return val === "tuna";
+				yummyFish: {
+					validate: function(val){
+						return val === "tuna";
+					},
+					message: "{0} should be equal to tuna."
 				}
 			};
 
@@ -50,8 +59,11 @@ describe('Custom Types', function() {
 		it(' should support providing context for rules via',function () {
 			var user = { password: 'passW0rd', passwordConfirmation: 'passW0rd' };
 
-			anchor.define('password', function (password) {
-				return password === this.passwordConfirmation;
+			anchor.define('password', {
+				validate: function (password) {
+					return password === this.passwordConfirmation;
+				},
+				message: "{0} should equals the confirmation."
 			});
 
 			var outcome = anchor(user.password).to({ type: 'password' }, user);


### PR DESCRIPTION
In my opinion the validation rules should be more flexible than single functions. They should support custom error messages (#29) and perhaps other goodies that would come later. That's why I suggest splitting them into separate files / objects that would be easier to maintain and present more opportunities for extension.

Currently I have implemented them in a folder /rules and every rule inside is loaded automatically.
I have implemented some example error messages that in my opinion are more human-readable than the current.

If you like the idea of this refactoring we could continue polishing the code : ))

Note: I am also thinking of adding more tests for the rules.
