### PR TITLE
Migrate to validator 3.1.0

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -3,7 +3,7 @@
  */
 
 var _ = require('lodash');
-var check = require('validator').check;
+var validator = require('validator');
 
 
 
@@ -21,7 +21,7 @@ module.exports = {
 		else if(typeof x.toString !== 'undefined') x = x.toString();
 		else x = '' + x;
 
-		return check(x).notEmpty();
+		return !validator.isNull(x);
 	},
 
 	'notEmpty'	: function (x) {
@@ -31,7 +31,7 @@ module.exports = {
 		else if (typeof x.toString !== 'undefined') x = x.toString();
 		else x = '' + x;
 
-		return check(x).notEmpty();
+		return !validator.isNull(x);
 	},
 
 	'undefined'	: _.isUndefined,
@@ -46,34 +46,34 @@ module.exports = {
 
 	'text'		: _.isString,
 	'string'	: _.isString,
-    'alpha'     : function (x){ return check(x).isAlpha();},
+	'alpha'		: validator.isAlpha,
 	'alphadashed': function (x) {return /^[a-zA-Z-_]*$/.test(x)},
-	'numeric'	: function (x){ return check(x).isNumeric();},
-    'alphanumeric': function (x){ return check(x).isAlphanumeric();},
+	'numeric'	: validator.isNumeric,
+	'alphanumeric': validator.isAlphanumeric,
 	'alphanumericdashed': function (x) {return /^[a-zA-Z0-9-_]*$/.test(x)},
-	'email'		: function (x){ return check(x).isEmail();},
-	'url'		: function (x){ return check(x).isUrl();},
+	'email'		: validator.isEmail,
+	'url'			: validator.isUrl,
 	'urlish'	: /^\s([^\/]+\.)+.+\s*$/g,
-	'ip'		: function (x){ return check(x).isIP(); },
-	'ipv4'		: function (x){ return check(x).isIPv4(); },
-	'ipv6'		: function (x){ return check(x).isIPv6(); },
-	'creditcard': function (x){ return check(x).isCreditCard();},
-	'uuid'		: function (x, version){ return check(x).isUUID(version);},
-	'uuidv3'	: function (x){ return check(x).isUUIDv3();},
-	'uuidv4'	: function (x){ return check(x).isUUIDv4();},
+	'ip'			: validator.isIP,
+	'ipv4'		: validator.isIPv4,
+	'ipv6'		: validator.isIPv6,
+	'creditcard': validator.isCreditCard,
+	'uuid'		: validator.isUUID,
+	'uuidv3'	: function (x){ return validator.isUUID(x, 3);},
+	'uuidv4'	: function (x){ return validator.isUUID(x, 3);},
 
-	'int'		: function (x) { return check(x).isInt(); },
-	'integer'	: function (x) { return check(x).isInt(); },
+	'int'			: validator.isInt,
+	'integer'	: validator.isInt,
 	'number'	: _.isNumber,
 	'finite'	: _.isFinite,
 
-	'decimal'	: function (x) { return check(x).isDecimal(); },
-	'float'		: function (x) { return check(x).isDecimal(); },
+	'decimal'	: validator.isDecimal,
+	'float'		: validator.isDecimal,
 
 	'falsey'	: function (x) { return !x; },
 	'truthy'	: function (x) { return !!x; },
 	'null'		: _.isNull,
-	'notNull'	: function (x) { return check(x).notNull(); },
+	'notNull'	: function (x) { return !validator.isNull(x); },
 
 	'boolean'	: _.isBoolean,
 
@@ -81,33 +81,34 @@ module.exports = {
 
 	'binary'	: function (x) { return Buffer.isBuffer(x) || _.isString(x); },
 
-	'date'		: function (x) { return check(x).isDate(); },
-	'datetime': function (x) { return check(x).isDate(); },
+	'date'		: validator.isDate,
+	'datetime': validator.isDate,
 
-	'hexadecimal': function (x) { return check(x).hexadecimal(); },
-	'hexColor': function (x) { return check(x).isHexColor(); },
+	'hexadecimal': validator.hexadecimal,
+	'hexColor': validator.isHexColor,
 
-	'lowercase': function (x) { return check(x).lowercase(); },
-	'uppercase': function (x) { return check(x).uppercase(); },
+	'lowercase': validator.lowercase,
+	'uppercase': validator.uppercase,
 
 	// Miscellaneous rules
-	'after'		: function (x,date) { return check(x).isAfter(date); },
-	'before'	: function (x,date) { return check(x).isBefore(date); },
+	'after'		: validator.isAfter,
+	'before'	: validator.isBefore,
 
-	'is'		: function (x, regex) { return check(x).is(regex); },
-	'regex'		: function (x, regex) { return check(x).regex(regex); },
-	'not'		: function (x, regex) { return check(x).not(regex); },
-	'notRegex'	: function (x, regex) { return check(x).notRegex(regex); },
-
-	'equals'	: function (x, equals) { return check(x).equals(equals); },
-	'contains'	: function (x, str) { return check(x).contains(str); },
-	'notContains': function (x, str) { return check(x).notContains(str); },
-	'len'		: function (x, min, max) { return check(x).len(min, max); },
-	'in'		: function (x, arrayOrString) { return check(x).isIn(arrayOrString); },
-	'notIn'		: function (x, arrayOrString) { return check(x).notIn(arrayOrString); },
-	'max'		: function (x, val) { return check(x).max(val); },
-	'min'		: function (x, val) { return check(x).min(val); },
-	'minLength'	: function (x, min) { return check(x).len(min); },
-	'maxLength'	: function (x, max) { return check(x).len(0, max); }
+	'equals'	: validator.equals,
+	'contains': validator.contains,
+	'notContains': function (x, str) { return !validator.contains(x, str); },
+	'len'			: function (x, min, max) { return validator.len(x, min, max); },
+	'in'			: validator.isIn,
+	'notIn'		: function (x, arrayOrString) { return !validator.isIn(x, arrayOrString); },
+	'max'			: function (x, val) {
+		var number = parseFloat(x);
+		return isNaN(number) || number <= val;
+	},
+	'min'			: function (x, val) {
+		var number = parseFloat(x);
+		return isNaN(number) || number >= val;
+	},
+	'minLength'	: function (x, min) { return validator.isLength(x, min); },
+	'maxLength'	: function (x, max) { return validator.isLength(x, 0, max); }
 
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "validator": "~2.0.0",
+    "validator": "~3.1.0",
     "lodash": "~2.4.1",
     "async": "0.2.9"
   },


### PR DESCRIPTION
Validator v3+ got rid of chaining and just uses
the base validator object.  Migrate the tests to use
the validator v3 syntax.

Validator v3 has removed the regex checks,
including `is` and `not`.  Those are now
removed from anchor too, and there's no tests
that use these validations.
