### PR TITLE
Fixed reference to isURL validator function

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -52,7 +52,7 @@ module.exports = {
 	'alphanumeric': validator.isAlphanumeric,
 	'alphanumericdashed': function (x) {return (/^[a-zA-Z0-9-_]*$/).test(x); },
 	'email'		: validator.isEmail,
-	'url'			: validator.isUrl,
+	'url'			: validator.isURL,
 	'urlish'	: /^\s([^\/]+\.)+.+\s*$/g,
 	'ip'			: validator.isIP,
 	'ipv4'		: validator.isIPv4,


### PR DESCRIPTION
https://github.com/chriso/validator.js/blob/master/validator.js#L164

It was hard to find the specific reason for my `type: 'url'` model attribute in sails failing since the error message was saying that the validation failed, not that the validator function was undefined or something like that. I then tried putting `type: 'caca'` in the attribute and it still threw that the value for the field was wrong instead of saying that `caca` is not a valid type hahaha.

I'm not sure if other changes are needed. Please advice.
