### PR TITLE
url - allow true as option

### DIFF
--- a/lib/match/rules.js
+++ b/lib/match/rules.js
@@ -54,7 +54,7 @@ module.exports = {
 	'alphanumeric': validator.isAlphanumeric,
 	'alphanumericdashed': function (x) {return (/^[a-zA-Z0-9-_]*$/).test(x); },
 	'email'		: validator.isEmail,
-	'url'			: validator.isURL,
+	'url'			: function(x, opt) { return validator.isURL(x, opt === true ? undefined : opt); },
 	'urlish'	: /^\s([^\/]+\.)+.+\s*$/g,
 	'ip'			: validator.isIP,
 	'ipv4'		: validator.isIPv4,

--- a/test/miscellaneousRules.test.js
+++ b/test/miscellaneousRules.test.js
@@ -37,6 +37,17 @@ describe('miscellaneous rules', function() {
                 });
         });
 
+	describe('url', function () {
+
+		it ('should support "url" rule with no options', function () {
+			return testRules({ url: true }, 'http://sailsjs.org', 'sailsjs');
+		});
+
+		it ('should support "url" rule with options', function () {
+			return testRules({ url: { require_protocol: true} }, 'http://sailsjs.org', 'www.sailsjs.org');
+		});
+	});
+
 	describe('before/after date', function () {
 		it (' should support "before" rule ', function () {
 			return testRules({


### PR DESCRIPTION
Fixes Issue #62 

This allows you to use `true` with `url` and also pass options:

```
url: true
```

```
url: { require_protocol: true }
```
