### PR TITLE
Added time validator (which was breaking waterline ORM)

### DIFF
--- a/lib/match/rules.js
+++ b/lib/match/rules.js
@@ -4,7 +4,7 @@
 
 var _ = require('lodash');
 var validator = require('validator');
-
+var moment = require('moment');
 
 
 /**
@@ -85,6 +85,7 @@ module.exports = {
 
 	'date'		: validator.isDate,
 	'datetime': validator.isDate,
+	'time': function(x) {return moment(x, "hh:mm:ss a").isValid();},
 
 	'hexadecimal': validator.hexadecimal,
 	'hexColor': validator.isHexColor,

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
   "license": "MIT",
   "readmeFilename": "README.md",
   "dependencies": {
-    "validator": "~3.22.0",
-    "lodash": "~2.4.1"
+    "lodash": "~2.4.1",
+    "moment": "^2.9.0",
+    "validator": "~3.22.0"
   },
   "devDependencies": {
     "async": "~0.2.10",


### PR DESCRIPTION
Using moment to validate that it is a correct time field. The reason it is using the "hh:mm:ss a" format is because that is the default format understood by various databases. This fixes the waterline orm issue with time fields.
