### PR TITLE
Added geojsonhint as a dependency to fix issues with SailsJS version 0.12.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "@mapbox/geojsonhint": "1.2.1",
     "@sailshq/lodash": "^3.10.2",
-    "validator": "4.4.0"
+    "validator": "4.4.0",
+    "geojsonhint": "2.0.0"
   },
   "devDependencies": {
     "async": "~0.2.10",


### PR DESCRIPTION
This commit fixes this issue: 
https://github.com/balderdashy/sails/issues/3994

> If I run 'sails new app' everything installs fine. If I go into the new app 'cd app' and run 'npm install' it runs fine. If I wipe out the 'node_modules' directory and run 'npm install' I get the same errors:
> 
>` npm ERR! enoent ENOENT: no such file or directory, chmod '/vagrant/backend/node_modules/sails/node_modules/anchor/node_modules/geojsonhint/node_modules/jsonlint-lines/node_modules/nomnom/node_modules/chalk/node_modules/strip-ansi/cli.js'`
