### PR TITLE
Fix balderdashy/waterline#1589

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -259,7 +259,7 @@ var rules = {
       return x.length <= maxLength;
     },
     expectedTypes: ['json', 'ref', 'string'],
-    defaultErrorMessage: function(x, maxLength) { return 'Value was '+(maxLength-x.length)+' character'+((maxLength-x.length !== 1) ? 's' : '')+' longer than the configured maximum length (' + maxLength + ')'; },
+    defaultErrorMessage: function(x, maxLength) { return 'Value was '+(x.length-maxLength)+' character'+((x.length-maxLength !== 1) ? 's' : '')+' longer than the configured maximum length (' + maxLength + ')'; },
     ignoreEmptyString: true,
     checkConfig: function(constraint) {
       if (typeof constraint !== 'number' && parseInt(constraint) !== constraint) {


### PR DESCRIPTION
This resolves a super simple issue where the overage amount displayed for the `maxLength` rule’s default error message was always displayed as a negative number, for example: “Value was -4 characters longer than the configured maximum length”

See the corresponding issue for more information: https://github.com/balderdashy/waterline/issues/1589